### PR TITLE
[EPIC] Ingestor multi-sources — implémentation

### DIFF
--- a/docs/epics/EPIC-ingestor.md
+++ b/docs/epics/EPIC-ingestor.md
@@ -1,0 +1,13 @@
+# EPIC Ingestor (multi-sources)
+Objectif: Ingestion URL, fichiers (PDF/DOCX/TXT), Google Drive (fileId/dossier), dédup, métadonnées, embeddings via Ollama, stockage Chroma v2.
+## Tâches
+- [ ] Contrat POST /ingest (source_type in {url,file,gdrive})
+- [ ] URL: fetch robuste + extraction texte
+- [ ] Fichiers: unstructured (tailles/erreurs)
+- [ ] GDrive: service account, scopes, by fileId et folder
+- [ ] Dédup: SHA256
+- [ ] Chunking: splitters configurables
+- [ ] Embeddings: nomic-embed-text, Chroma v2 (collection configurable)
+- [ ] Métadonnées: uri, ingest_ts, hints
+- [ ] Retours `{status, added, skipped}` + logs clairs
+- [ ] Tests: example.com, GDrive public/privé, query v2 ok


### PR DESCRIPTION
Tracks #2

PR d'implémentation de l'épopée **Ingestor multi-sources**.
Voir `docs/epics/EPIC-ingestor.md` et **SPEC.md** pour les détails.

- [ ] URL/fichiers/GDrive
- [ ] Dédup + métadonnées
- [ ] Embeddings + Chroma v2
- [ ] Tests end-to-end
