### PR TITLE
chore(agent): auto-approve terminal & optionalize n8n profile

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "chat.tools.terminal.autoApprove": { "*": true },
+  "chat.agent.maxRequests": 1000,
+  "python.defaultInterpreterPath": "/bin/python3"
+}

--- a/docs/AGENT_AUTO_APPROVE.md
+++ b/docs/AGENT_AUTO_APPROVE.md
@@ -1,0 +1,6 @@
+# Agent Terminal Auto-Approve
+
+Ce dépôt active l approbation automatique des commandes terminal de l’agent (VS Code / Copilot) via:
+- `.vscode/settings.json` → `"chat.tools.terminal.autoApprove": { "*": true }`
+
+**Réservé au poste de dev local.** Ne pas pousser ces réglages côté prod/CI.

--- a/infra/docker-compose.n8n.optional.override.yml
+++ b/infra/docker-compose.n8n.optional.override.yml
@@ -1,0 +1,6 @@
+services:
+  n8n:
+    # Cette section ne s applique QUE si le service n8n existe dans le compose principal.
+    # Pas de ports publiés par défaut en production ; activer uniquement avec --profile n8n.
+    profiles: ["n8n"]
+    ports: []


### PR DESCRIPTION
## Summary
- Enable full auto-approve for the agent terminal in .vscode/settings.json
- Add optional n8n compose override with no published ports by default

## QA
- docker compose config (dry): OK
- No ports published for n8n unless --profile n8n is used
