### PR TITLE
Hardening for v1.0.0: Nginx rate limiting, systemd unit, CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+## v1.0.0 (2025-11-15)
+
+- Host-managed Nginx: TLS for UI and API, secure headers, /metrics restricted to loopback.
+- Removal of n8n from the stack (dev/prod) to simplify and harden production.
+- Ingestor API hardened: Authorization: Bearer (X-API-Token compatible), IP allowlist, metrics gating.
+- New external Search API: `POST /search` with the same embedding model as indexing for semantic parity.
+- Production Compose: loopback bindings, Prometheus optional profile, resource limits and healthchecks.
+- CLI ingestion tool for cron jobs: `scripts/ingest-cli.py` (+ requirements-cli).
+- CI: Lint, typecheck, tests with coverage gate (≥80% on src/ingestor), and Smoke (Compose) end-to-end.
+- Documentation: README-PROD updated, `docs/kb-api.md`, Nginx templates and guide, ops checklist.
+- Hardening: Nginx rate limiting for `/ingest` and `/search` (20 r/s, burst 40) in API vhost template.
+- Systemd: service template and installer for reliable boot/start/stop of the Compose stack.

--- a/README-PROD.md
+++ b/README-PROD.md
@@ -32,6 +32,19 @@ docker compose -f infra/docker-compose.yml --env-file infra/.env up -d
 docker compose -f infra/docker-compose.prod.yml --env-file infra/.env --profile db --profile llm --profile api --profile ui --profile obs up -d
 ```
 
+## Service systemd (recommandé en prod)
+```bash
+# depuis la racine du dépôt déjà synchronisé sur le VPS
+export RAG_DIR=/srv/rag-local
+sudo mkdir -p "$RAG_DIR"
+sudo rsync -a --delete ./ "$RAG_DIR"/
+cd "$RAG_DIR"
+# rendre le service et l'installer
+./infra/scripts/install-systemd.sh
+# vérifier
+systemctl status rag-local.service --no-pager
+```
+
 ## Exposition HTTPS (Nginx + Certbot)
 
 - Utiliser `infra/nginx/rag-ui.conf.template` et `infra/nginx/rag-api.conf.template` avec `envsubst` pour générer les vhosts (les templates n’emploient pas `${VAR:-def}`).

--- a/infra/nginx/README.md
+++ b/infra/nginx/README.md
@@ -28,3 +28,7 @@ sudo certbot --nginx -d "$RAG_API_EXTERNAL_DOMAIN" --redirect
 
 Certbot ajoutera automatiquement les blocs HTTPS.
 Ajoutez `add_header Strict-Transport-Security "max-age=63072000" always;` dans les blocs HTTPS de production.
+
+Rate limiting
+- Le vhost API inclut une zone `limit_req_zone` (20 r/s, burst 40) appliquée à `/ingest` et `/search`.
+- Ajustez ces valeurs si nécessaire en éditant `infra/nginx/rag-api.conf.template` avant rendu.

--- a/infra/nginx/rag-api.conf.template
+++ b/infra/nginx/rag-api.conf.template
@@ -1,4 +1,7 @@
 # API reverse proxy with TLS and local-only /metrics
+# Rate limiting zone (per-IP) for API endpoints; 20 req/s with burst 40
+limit_req_zone $binary_remote_addr zone=api_rate:10m rate=20r/s;
+
 server {
   listen 80;
   server_name ${RAG_API_EXTERNAL_DOMAIN};
@@ -15,12 +18,13 @@ server {
   include /etc/letsencrypt/options-ssl-nginx.conf;
   ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
 
-  client_max_body_size 100m;
+  client_max_body_size ${NGINX_CLIENT_MAX_BODY_SIZE};
   add_header X-Content-Type-Options "nosniff" always;
   add_header Referrer-Policy "no-referrer" always;
   add_header X-Frame-Options "SAMEORIGIN" always;
   add_header Permissions-Policy "geolocation=(), microphone=(), camera=()" always;
 
+  # Protect metrics endpoint (local only)
   location /metrics {
     allow 127.0.0.1;
     deny all;
@@ -29,6 +33,32 @@ server {
     proxy_set_header X-Forwarded-For $remote_addr;
   }
 
+  # Explicit rate-limited API endpoints
+  location = /ingest {
+    limit_req zone=api_rate burst=40 nodelay;
+    proxy_pass http://127.0.0.1:${NGINX_API_PORT}/ingest;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_set_header Host $host;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_read_timeout 300s;
+  }
+
+  location = /search {
+    limit_req zone=api_rate burst=40 nodelay;
+    proxy_pass http://127.0.0.1:${NGINX_API_PORT}/search;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_set_header Host $host;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_read_timeout 300s;
+  }
+
+  # Default pass-through for other endpoints
   location / {
     proxy_pass http://127.0.0.1:${NGINX_API_PORT};
     proxy_http_version 1.1;

--- a/infra/scripts/install-systemd.sh
+++ b/infra/scripts/install-systemd.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Installs/updates the rag-local systemd unit on the host.
+# Usage:
+#   RAG_DIR=/srv/rag-local ./infra/scripts/install-systemd.sh
+# Defaults:
+RAG_DIR=${RAG_DIR:-/srv/rag-local}
+SERVICE_NAME=rag-local.service
+TEMPLATE=infra/systemd/rag-local.service.template
+
+if [ ! -d "$RAG_DIR" ]; then
+  echo "RAG_DIR does not exist: $RAG_DIR" >&2
+  exit 1
+fi
+if [ ! -f "$TEMPLATE" ]; then
+  echo "Template missing: $TEMPLATE" >&2
+  exit 1
+fi
+
+# Render service file using envsubst
+export RAG_DIR
+TMP_FILE=$(mktemp)
+trap 'rm -f "$TMP_FILE"' EXIT
+if ! command -v envsubst >/dev/null 2>&1; then
+  echo "envsubst is required (install gettext-base)" >&2
+  exit 1
+fi
+envsubst < "$TEMPLATE" > "$TMP_FILE"
+
+# Install service
+sudo install -m 0644 "$TMP_FILE" "/etc/systemd/system/${SERVICE_NAME}"
+sudo systemctl daemon-reload
+sudo systemctl enable "$SERVICE_NAME"
+sudo systemctl restart "$SERVICE_NAME"
+
+echo "Installed and started systemd unit: ${SERVICE_NAME} (RAG_DIR=$RAG_DIR)"

--- a/infra/systemd/rag-local.service.template
+++ b/infra/systemd/rag-local.service.template
@@ -1,0 +1,16 @@
+[Unit]
+Description=rag-local stack (docker compose)
+After=docker.service network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+WorkingDirectory=${RAG_DIR}
+Environment=COMPOSE_PROFILES=db,llm,api,ui,obs
+ExecStart=/usr/bin/docker compose -f infra/docker-compose.prod.yml --env-file infra/.env --profile db --profile llm --profile api --profile ui --profile obs up -d
+ExecStop=/usr/bin/docker compose -f infra/docker-compose.prod.yml --env-file infra/.env down
+TimeoutStartSec=0
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
- Nginx API: limit_req for /ingest and /search (20 r/s, burst 40), body size via NGINX_CLIENT_MAX_BODY_SIZE\n- Systemd: rag-local.service template + install script (envsubst-based), recommended for prod\n- CHANGELOG.md for v1.0.0\n- README-PROD: systemd section; nginx README: rate limiting notes\n\nCI should pass; safe for merge into prod/vps-ready.