### PR TITLE
Improve Maths Première ingestion and OCR recovery

### DIFF
--- a/scripts/backfill_dedicated_collection.py
+++ b/scripts/backfill_dedicated_collection.py
@@ -1,0 +1,181 @@
+"""Backfill a dedicated Chroma collection from an existing source collection.
+
+Example:
+    python scripts/backfill_dedicated_collection.py \
+        --source rag_education \
+        --target rag_maths_premiere \
+        --section maths_premiere \
+        --filter matiere=Mathématiques \
+        --filter niveau=Première \
+        --filter "groupe=Enseignements de spécialité (EDS)"
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+import chromadb
+
+
+def build_where(filters: Mapping[str, str]) -> dict[str, Any]:
+    """Build a Chroma where clause from key/value filters."""
+    conditions = [{key: value} for key, value in filters.items() if value]
+    if not conditions:
+        return {}
+    if len(conditions) == 1:
+        return conditions[0]
+    return {"$and": conditions}
+
+
+def rewrite_metadata(
+    metadata: Mapping[str, Any] | None,
+    *,
+    target_collection: str,
+    target_section: str,
+) -> dict[str, Any]:
+    """Rewrite collection-specific metadata for the destination collection."""
+    rewritten = dict(metadata or {})
+    rewritten["collection"] = target_collection
+    rewritten["section"] = target_section
+    return rewritten
+
+
+def select_rows_for_backfill(
+    *,
+    rows: Mapping[str, Sequence[Any]],
+    target_collection: str,
+    target_section: str,
+    existing_ids: set[str],
+) -> tuple[list[str], list[str], list[dict[str, Any]], list[Any]]:
+    """Return rows that still need to be inserted in the target collection."""
+    ids = list(rows.get("ids") or [])
+    documents = list(rows.get("documents") or [])
+    metadatas = list(rows.get("metadatas") or [])
+    raw_embeddings = rows.get("embeddings")
+    embeddings = list(raw_embeddings) if raw_embeddings is not None else []
+
+    ids_to_add: list[str] = []
+    docs_to_add: list[str] = []
+    metas_to_add: list[dict[str, Any]] = []
+    embs_to_add: list[Any] = []
+
+    for idx, chunk_id in enumerate(ids):
+        if chunk_id in existing_ids:
+            continue
+        ids_to_add.append(chunk_id)
+        docs_to_add.append(str(documents[idx]))
+        metas_to_add.append(
+            rewrite_metadata(
+                metadatas[idx] if idx < len(metadatas) else None,
+                target_collection=target_collection,
+                target_section=target_section,
+            )
+        )
+        emb = embeddings[idx] if idx < len(embeddings) else None
+        if hasattr(emb, "tolist"):
+            emb = emb.tolist()
+        embs_to_add.append(emb)
+
+    return ids_to_add, docs_to_add, metas_to_add, embs_to_add
+
+
+def backfill_collection(
+    *,
+    chroma_host: str,
+    chroma_port: int,
+    source_collection: str,
+    target_collection: str,
+    target_section: str,
+    filters: Mapping[str, str],
+    batch_size: int = 100,
+    dry_run: bool = False,
+) -> dict[str, int]:
+    """Copy matching chunks from a source collection into a dedicated collection."""
+    client = chromadb.HttpClient(host=chroma_host, port=chroma_port)
+    source = client.get_or_create_collection(
+        name=source_collection,
+        metadata={"hnsw:space": "cosine"},
+    )
+    target = client.get_or_create_collection(
+        name=target_collection,
+        metadata={"hnsw:space": "cosine"},
+    )
+
+    rows = source.get(
+        where=build_where(filters),
+        include=["documents", "metadatas", "embeddings"],
+    )
+    ids = list(rows.get("ids") or [])
+    existing_ids = set((target.get(ids=ids) or {}).get("ids", [])) if ids else set()
+    ids_to_add, docs_to_add, metas_to_add, embs_to_add = select_rows_for_backfill(
+        rows=rows,
+        target_collection=target_collection,
+        target_section=target_section,
+        existing_ids=existing_ids,
+    )
+
+    if not dry_run:
+        for start in range(0, len(ids_to_add), batch_size):
+            target.add(
+                ids=ids_to_add[start:start + batch_size],
+                documents=docs_to_add[start:start + batch_size],
+                metadatas=metas_to_add[start:start + batch_size],
+                embeddings=embs_to_add[start:start + batch_size],
+            )
+
+    return {
+        "source_matches": len(ids),
+        "preexisting": len(existing_ids),
+        "added": 0 if dry_run else len(ids_to_add),
+        "target_count": target.count() if not dry_run else target.count(),
+    }
+
+
+def _parse_filter(raw_value: str) -> tuple[str, str]:
+    if "=" not in raw_value:
+        raise argparse.ArgumentTypeError("Expected KEY=VALUE")
+    key, value = raw_value.split("=", 1)
+    key = key.strip()
+    value = value.strip()
+    if not key or not value:
+        raise argparse.ArgumentTypeError("Expected KEY=VALUE")
+    return key, value
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Backfill a dedicated Chroma collection from a source collection.")
+    parser.add_argument("--chroma-host", default="localhost", help="Chroma host")
+    parser.add_argument("--chroma-port", type=int, default=8000, help="Chroma port")
+    parser.add_argument("--source", required=True, help="Source collection name")
+    parser.add_argument("--target", required=True, help="Target collection name")
+    parser.add_argument("--section", required=True, help="Target section metadata value")
+    parser.add_argument(
+        "--filter",
+        dest="filters",
+        action="append",
+        type=_parse_filter,
+        default=[],
+        help="Metadata filter as KEY=VALUE. May be repeated.",
+    )
+    parser.add_argument("--batch-size", type=int, default=100, help="Number of chunks per add batch")
+    parser.add_argument("--dry-run", action="store_true", help="Show what would be copied without writing")
+    args = parser.parse_args()
+
+    summary = backfill_collection(
+        chroma_host=args.chroma_host,
+        chroma_port=args.chroma_port,
+        source_collection=args.source,
+        target_collection=args.target,
+        target_section=args.section,
+        filters=dict(args.filters),
+        batch_size=args.batch_size,
+        dry_run=args.dry_run,
+    )
+    print(json.dumps(summary, ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/ingestor/api.py
+++ b/src/ingestor/api.py
@@ -90,6 +90,12 @@ COLLECTION_MAP: dict[str, str] = {
     "default": "rag_education",
 }
 
+MATHS_PREMIERE_FALLBACK_FILTERS: dict[str, str] = {
+    "matiere": "Mathématiques",
+    "niveau": "Première",
+    "groupe": "Enseignements de spécialité (EDS)",
+}
+
 
 def resolve_collection_name(section: str | None = None, collection: str | None = None) -> str:
     """Resolve the ChromaDB collection name from section or explicit collection name."""
@@ -97,6 +103,33 @@ def resolve_collection_name(section: str | None = None, collection: str | None =
         return collection.strip().lower()
     sec = (section or "default").strip().lower()
     return COLLECTION_MAP.get(sec, COLLECTION_MAP["default"])
+
+
+def _resolve_search_target(
+    client: Any,
+    payload: SearchRequest,
+) -> tuple[str, dict[str, Any], bool]:
+    """Resolve the collection and effective filters for a search request."""
+    requested_collection = resolve_collection_name(
+        section=payload.section,
+        collection=payload.collection or None,
+    )
+    effective_filters = dict(payload.filters)
+    maths_fallback_applied = False
+
+    if (payload.section or "").strip().lower() != "maths_premiere":
+        return requested_collection, effective_filters, maths_fallback_applied
+
+    dedicated_collection = client.get_or_create_collection(
+        name=COLLECTION_MAP["maths_premiere"],
+        metadata={"hnsw:space": "cosine"},
+    )
+    if dedicated_collection.count() > 0:
+        return requested_collection, effective_filters, maths_fallback_applied
+
+    effective_filters.update(MATHS_PREMIERE_FALLBACK_FILTERS)
+    maths_fallback_applied = True
+    return COLLECTION_MAP["education"], effective_filters, maths_fallback_applied
 
 CHROMA_REQUEST_TIMEOUT = float(os.getenv("CHROMA_REQUEST_TIMEOUT", "30"))
 OLLAMA_REQUEST_TIMEOUT = float(os.getenv("OLLAMA_REQUEST_TIMEOUT", "30"))
@@ -1799,12 +1832,10 @@ def search_kb(payload: SearchRequest, request: Request) -> dict[str, Any]:
     _require_api_token_configured()
     _enforce_security(request, payload)
 
-    # Resolve collection from section or explicit name
-    target_col = resolve_collection_name(section=payload.section, collection=payload.collection or None)
-
     # Prepare chroma collection
     try:
         client = get_chroma_client()
+        target_col, effective_filters, maths_fallback_applied = _resolve_search_target(client, payload)
         collection = client.get_or_create_collection(name=target_col, metadata={"hnsw:space": "cosine"})
     except Exception as exc:  # pragma: no cover - defensive
         raise HTTPException(status_code=500, detail=f"Chroma client error: {exc}") from exc
@@ -1833,9 +1864,9 @@ def search_kb(payload: SearchRequest, request: Request) -> dict[str, Any]:
     # Build metadata filters from payload.filters
     # ChromaDB requires $and operator when multiple conditions are present
     where: dict[str, Any] = {}
-    if payload.filters:
+    if effective_filters:
         conditions = []
-        for fk, fv in payload.filters.items():
+        for fk, fv in effective_filters.items():
             if fv is not None and fv != "" and fv != "Tous":
                 conditions.append({str(fk): fv})
         if len(conditions) == 1:
@@ -1882,6 +1913,7 @@ def search_kb(payload: SearchRequest, request: Request) -> dict[str, Any]:
         "returned": len(hits),
         "filters_applied": where,
         "score_threshold": payload.score_threshold,
+        "maths_premiere_fallback": maths_fallback_applied,
         "hits": hits,
     }
 

--- a/src/ingestor/api.py
+++ b/src/ingestor/api.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import hashlib
+import io
 import importlib
 import importlib.util
 import ipaddress
@@ -579,6 +580,84 @@ def load_markdown(file_path: Path) -> list[Document]:
 
     metadata = {"source": str(file_path), "mime_type": "text/markdown"}
     return [Document(page_content=text, metadata=metadata)]
+
+
+def _ocr_pdf_bytes(pdf_bytes: bytes, max_pages: int = 5) -> list[str]:
+    """OCR a PDF by rendering a bounded number of pages to images first."""
+    if not pdf_bytes:
+        return []
+
+    try:
+        import subprocess
+
+        import pytesseract
+        from PIL import Image
+    except ImportError:
+        return []
+
+    texts: list[str] = []
+    with tempfile.TemporaryDirectory(dir="/tmp") as tmpdir:
+        pdf_path = Path(tmpdir) / "input.pdf"
+        pdf_path.write_bytes(pdf_bytes)
+        output_prefix = Path(tmpdir) / "page"
+        subprocess.run(
+            [
+                "pdftoppm",
+                "-png",
+                "-r",
+                "200",
+                "-f",
+                "1",
+                "-l",
+                str(max(1, max_pages)),
+                str(pdf_path),
+                str(output_prefix),
+            ],
+            check=True,
+            capture_output=True,
+            timeout=120,
+        )
+        for image_path in sorted(Path(tmpdir).glob("page-*.png")):
+            with Image.open(image_path) as image:
+                try:
+                    text = pytesseract.image_to_string(image, lang="fra+eng")
+                except Exception:
+                    text = pytesseract.image_to_string(image, lang="eng")
+            cleaned = (text or "").strip()
+            if cleaned:
+                texts.append(cleaned)
+    return texts
+
+
+def _extract_pdf_documents_from_bytes(pdf_bytes: bytes, source_name: str) -> list[Document]:
+    """Extract per-page PDF documents, using OCR only when text extraction is empty."""
+    docs: list[Document] = []
+    with pdfplumber.open(io.BytesIO(pdf_bytes)) as pdf_doc:
+        for page_index, page in enumerate(pdf_doc.pages):
+            text = (page.extract_text() or "").strip()
+            if text:
+                docs.append(
+                    Document(
+                        page_content=text,
+                        metadata={"source": source_name, "page": page_index},
+                    )
+                )
+    if docs:
+        return docs
+
+    for page_index, text in enumerate(_ocr_pdf_bytes(pdf_bytes)):
+        docs.append(
+            Document(
+                page_content=text,
+                metadata={"source": source_name, "page": page_index, "ocr": "true"},
+            )
+        )
+    return docs
+
+
+def _documents_have_text(docs: list[Any]) -> bool:
+    """Return True when at least one loaded document has non-empty text content."""
+    return any((getattr(doc, "page_content", "") or "").strip() for doc in docs)
 
 
 def _validate_remote_url(url: str) -> None:
@@ -1252,6 +1331,19 @@ def background_drive_ingest(folder_id: str, metadata: dict, task_id: str) -> Non
                     try:
                         loader = GoogleDriveLoader(**kwargs)
                         docs = loader.load()
+                        if not _documents_have_text(docs) and mime_type == "application/pdf":
+                            from google.oauth2 import service_account as _sa2
+                            from googleapiclient.discovery import build as _build2
+
+                            _creds_path2 = os.getenv("GOOGLE_APPLICATION_CREDENTIALS", "")
+                            _creds2 = _sa2.Credentials.from_service_account_file(
+                                _creds_path2, scopes=["https://www.googleapis.com/auth/drive.readonly"]
+                            )
+                            _svc2 = _build2("drive", "v3", credentials=_creds2, cache_discovery=False)
+                            pdf_bytes = _svc2.files().get_media(fileId=fid).execute()
+                            docs = _extract_pdf_documents_from_bytes(pdf_bytes, fname)
+                            if docs:
+                                logger.info(f"[{task_id}] pdf/OCR fallback OK after empty loader result: {fname}")
                     except Exception as e:
                         error_detail = str(e)
                         # Fallback pdfplumber pour PDFs corrompus (EOF marker not found)
@@ -1260,28 +1352,17 @@ def background_drive_ingest(folder_id: str, metadata: dict, task_id: str) -> Non
                             try:
                                 from google.oauth2 import service_account as _sa2
                                 from googleapiclient.discovery import build as _build2
-                                from langchain.schema import Document as _Doc2
                                 _creds_path2 = os.getenv("GOOGLE_APPLICATION_CREDENTIALS", "")
                                 _creds2 = _sa2.Credentials.from_service_account_file(
                                     _creds_path2, scopes=["https://www.googleapis.com/auth/drive.readonly"]
                                 )
                                 _svc2 = _build2("drive", "v3", credentials=_creds2, cache_discovery=False)
                                 pdf_bytes = _svc2.files().get_media(fileId=fid).execute()
-                                with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False, dir="/tmp") as tf2:
-                                    tf2.write(pdf_bytes)
-                                    tmp_pdf = tf2.name
-                                texts = []
-                                with pdfplumber.open(tmp_pdf) as pdf_doc:
-                                    for pg in pdf_doc.pages:
-                                        t = pg.extract_text()
-                                        if t and t.strip():
-                                            texts.append(t.strip())
-                                Path(tmp_pdf).unlink(missing_ok=True)
-                                if texts:
-                                    docs = [_Doc2(page_content="\n\n".join(texts), metadata={"source": fname})]
-                                    logger.info(f"[{task_id}] pdfplumber fallback OK: {fname} ({len(texts)} pages)")
+                                docs = _extract_pdf_documents_from_bytes(pdf_bytes, fname)
+                                if docs:
+                                    logger.info(f"[{task_id}] pdf/OCR fallback OK: {fname} ({len(docs)} pages)")
                                 else:
-                                    raise RuntimeError("pdfplumber extracted no text")
+                                    raise RuntimeError("pdfplumber/OCR extracted no text")
                             except Exception as _fe:
                                 logger.warning(f"[{task_id}] pdfplumber fallback failed for {fid}: {_fe}")
                                 error_detail2 = f"{error_detail} | pdfplumber: {_fe}"

--- a/src/ingestor/api.py
+++ b/src/ingestor/api.py
@@ -1099,7 +1099,7 @@ def background_drive_ingest(folder_id: str, metadata: dict, task_id: str) -> Non
             task.finished_at = time.time()
             return
 
-        updates = sync_manager.list_updates(folder_id)
+        updates = sync_manager.list_updates(folder_id, collection_name=target_col)
         if not updates:
             logger.info(f"[{task_id}] Aucune mise à jour pour le dossier Drive.")
             task.status = "done"
@@ -1304,7 +1304,11 @@ def background_drive_ingest(folder_id: str, metadata: dict, task_id: str) -> Non
                     continue
 
                 content_fingerprint = get_content_fingerprint([(doc.page_content or "") for doc in docs])
-                if sync_manager.is_unchanged(file_meta, content_fingerprint):
+                if sync_manager.is_unchanged(
+                    file_meta,
+                    content_fingerprint,
+                    collection_name=target_col,
+                ):
                     logger.info(f"[{task_id}] Skipping unchanged file {fid} ({fname})")
                     task.skipped_files += 1
                     task.processed_files += 1
@@ -1356,7 +1360,11 @@ def background_drive_ingest(folder_id: str, metadata: dict, task_id: str) -> Non
                     continue
 
                 # Mark as ingested
-                sync_manager.mark_as_ingested(file_meta, content_fingerprint=content_fingerprint)
+                sync_manager.mark_as_ingested(
+                    file_meta,
+                    content_fingerprint=content_fingerprint,
+                    collection_name=target_col,
+                )
 
             except Exception as e:
                 logger.error(f"[{task_id}] Error processing file {fid}: {e}")

--- a/src/ingestor/drive_sync.py
+++ b/src/ingestor/drive_sync.py
@@ -14,6 +14,7 @@ _DRIVE_SCOPES = [
     "https://www.googleapis.com/auth/drive.readonly",
 ]
 
+
 class DriveSyncManager:
     def __init__(self, db_path: str = "drive_sync_state.db"):
         # Use an absolute path for the DB to avoid CWD issues
@@ -98,7 +99,15 @@ class DriveSyncManager:
             pass
         return "<service-account>"
 
-    def list_updates(self, folder_id: str) -> list[dict[str, Any]]:
+    def _sync_key(self, file_id: str | None, collection_name: str | None = None) -> str:
+        """Return the storage key used in the sync DB for a given collection."""
+        normalized_file_id = str(file_id or "").strip()
+        normalized_collection = str(collection_name or "").strip().lower()
+        if not normalized_collection or normalized_collection == "rag_education":
+            return normalized_file_id
+        return f"{normalized_collection}:{normalized_file_id}"
+
+    def list_updates(self, folder_id: str, collection_name: str | None = None) -> list[dict[str, Any]]:
         """
         List files in folder (recursively) that are new or modified since last ingestion.
         Raises PermissionError if the folder is not accessible by the service account.
@@ -114,9 +123,10 @@ class DriveSyncManager:
                     file_id = f.get("id")
                     modified_time = f.get("modifiedTime")
                     drive_md5 = f.get("md5Checksum")
+                    sync_key = self._sync_key(file_id, collection_name)
                     cursor.execute(
                         "SELECT modified_time, md5_checksum FROM drive_files WHERE file_id = ?",
-                        (file_id,),
+                        (sync_key,),
                     )
                     row = cursor.fetchone()
                     if not row:
@@ -181,11 +191,19 @@ class DriveSyncManager:
         logger.info(f"Drive scan found {len(files)} files in folder tree {folder_id}")
         return files
 
-    def is_unchanged(self, file_meta: dict[str, Any], content_fingerprint: str = "") -> bool:
+    def is_unchanged(
+        self,
+        file_meta: dict[str, Any],
+        content_fingerprint: str = "",
+        collection_name: str | None = None,
+    ) -> bool:
         try:
             with sqlite3.connect(self.db_path) as conn:
                 cursor = conn.cursor()
-                cursor.execute("SELECT modified_time, md5_checksum, content_fingerprint FROM drive_files WHERE file_id = ?", (file_meta.get("id"),))
+                cursor.execute(
+                    "SELECT modified_time, md5_checksum, content_fingerprint FROM drive_files WHERE file_id = ?",
+                    (self._sync_key(file_meta.get("id"), collection_name),),
+                )
                 row = cursor.fetchone()
                 if not row:
                     return False
@@ -200,14 +218,19 @@ class DriveSyncManager:
             logger.error(f"Failed to compare file fingerprint: {e}")
             return False
 
-    def mark_as_ingested(self, file_meta: dict[str, Any], content_fingerprint: str = ""):
+    def mark_as_ingested(
+        self,
+        file_meta: dict[str, Any],
+        content_fingerprint: str = "",
+        collection_name: str | None = None,
+    ):
         try:
             with sqlite3.connect(self.db_path) as conn:
                 conn.execute("""
                     INSERT OR REPLACE INTO drive_files (file_id, name, modified_time, md5_checksum, content_fingerprint)
                     VALUES (?, ?, ?, ?, ?)
                 """, (
-                    file_meta.get("id"),
+                    self._sync_key(file_meta.get("id"), collection_name),
                     file_meta.get("name"),
                     file_meta.get("modifiedTime"),
                     file_meta.get("md5Checksum"),

--- a/src/ui/app_v2.py
+++ b/src/ui/app_v2.py
@@ -684,12 +684,23 @@ elif page == "🎓 Éducation":
 # ═══════════════════════════════════════════════════════════════
 elif page == "📐 Maths 1ère":
     st.title("📐 Maths Première — Spécialité")
+    maths_stats = api_get("/stats/rag_maths_premiere") or {}
+    maths_fallback_active = maths_stats.get("doc_count", 0) == 0
     st.markdown(
         "Collection dédiée **Mathématiques Première** (spécialité). "
-        "Tous les documents ingici sont indexés dans **`rag_maths_premiere`**, "
-        "collection isolée pour des résultats de recherche plus pertinents. "
-        "Elle est aussi incluse dans la recherche **Toutes** multi-collection."
+        "Les nouveaux documents ingérés ici sont indexés dans **`rag_maths_premiere`**."
     )
+    if maths_fallback_active:
+        st.warning(
+            "La collection dédiée est actuellement vide. Les recherches **Maths 1ère** "
+            "basculent temporairement sur **`rag_education`** avec les filtres "
+            "`Mathématiques / Première / Enseignements de spécialité (EDS)`."
+        )
+    else:
+        st.info(
+            "La recherche **Maths 1ère** utilise la collection dédiée "
+            "**`rag_maths_premiere`**."
+        )
 
     st.subheader("📂 Type de ressource")
     col_t, col_d = st.columns(2)
@@ -730,14 +741,18 @@ elif page == "📐 Maths 1ère":
 
     st.markdown("---")
     with st.expander("📊 Statistiques collection Maths 1ère", expanded=False):
-        stats = api_get("/stats/rag_maths_premiere")
-        if stats:
+        if maths_stats:
             c1, c2, c3 = st.columns(3)
-            c1.metric("Chunks", stats.get("doc_count", 0))
-            c2.metric("Types", len(stats.get("types_ressource", [])))
-            c3.metric("Embedding", stats.get("embed_model", "?"))
-            if stats.get("types_ressource"):
-                st.write(f"**Types** : {', '.join(stats['types_ressource'])}")
+            c1.metric("Chunks", maths_stats.get("doc_count", 0))
+            c2.metric("Types", len(maths_stats.get("types_ressource", [])))
+            c3.metric("Embedding", maths_stats.get("embed_model", "?"))
+            if maths_stats.get("types_ressource"):
+                st.write(f"**Types** : {', '.join(maths_stats['types_ressource'])}")
+            if maths_fallback_active:
+                st.caption(
+                    "Fallback actif: la recherche Maths 1ère est servie par "
+                    "`rag_education` avec filtres métier tant que cette collection reste vide."
+                )
 
 
 # ═══════════════════════════════════════════════════════════════
@@ -895,7 +910,11 @@ elif page == "🔍 Recherche":
                 filters["type_ressource"] = f_type
     elif search_section == "📐 Maths 1ère":
         section_key = "maths_premiere"
-        collection_key = "rag_maths_premiere"
+        collection_key = ""
+        st.caption(
+            "Recherche ciblée Maths 1ère. Si la collection dédiée est vide, "
+            "l'API bascule automatiquement sur `rag_education` avec les filtres adéquats."
+        )
     elif search_section == "🎓 Éducation":
         section_key = "education"
         collection_key = "rag_education"
@@ -933,11 +952,16 @@ elif page == "🔍 Recherche":
                 all_hits: list[dict[str, Any]] = []
                 searched_cols: list[str] = []
                 for col_name in ALL_COLLECTIONS:
+                    search_collection = col_name
+                    search_section = ""
+                    if col_name == "rag_maths_premiere":
+                        search_collection = ""
+                        search_section = "maths_premiere"
                     payload_col = _build_search_payload(
                         query=query,
                         k=k,
-                        collection=col_name,
-                        section="",
+                        collection=search_collection,
+                        section=search_section,
                         filters={},
                         score_threshold=score_threshold if use_score_threshold else None,
                     )

--- a/src/ui/app_v2.py
+++ b/src/ui/app_v2.py
@@ -971,9 +971,22 @@ elif page == "🔍 Recherche":
                             h["_collection"] = col_name
                         all_hits.extend(r["hits"])
                         searched_cols.append(col_name)
+                deduped_hits: dict[str, dict[str, Any]] = {}
+                for hit in all_hits:
+                    meta = hit.get("metadata", {})
+                    dedupe_key = str(
+                        meta.get("sha256")
+                        or hit.get("id")
+                        or meta.get("source")
+                        or ""
+                    ).strip()
+                    if not dedupe_key:
+                        dedupe_key = f"anon-{len(deduped_hits)}"
+                    current = deduped_hits.get(dedupe_key)
+                    if current is None or hit.get("score", 1.0) < current.get("score", 1.0):
+                        deduped_hits[dedupe_key] = hit
                 # Trier par score ascendant (distance cosinus — plus petit = meilleur)
-                all_hits.sort(key=lambda h: h.get("score", 1.0))
-                merged_hits = all_hits[:k]
+                merged_hits = sorted(deduped_hits.values(), key=lambda h: h.get("score", 1.0))[:k]
                 result: dict[str, Any] | None = {
                     "hits": merged_hits,
                     "collection": "toutes (" + ", ".join(searched_cols) + ")",

--- a/tests/test_backfill_dedicated_collection.py
+++ b/tests/test_backfill_dedicated_collection.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from scripts.backfill_dedicated_collection import build_where, select_rows_for_backfill
+
+
+def test_build_where_with_multiple_filters() -> None:
+    where = build_where({
+        "matiere": "Mathématiques",
+        "niveau": "Première",
+        "groupe": "Enseignements de spécialité (EDS)",
+    })
+
+    assert where == {
+        "$and": [
+            {"matiere": "Mathématiques"},
+            {"niveau": "Première"},
+            {"groupe": "Enseignements de spécialité (EDS)"},
+        ]
+    }
+
+
+def test_select_rows_for_backfill_rewrites_collection_metadata() -> None:
+    rows = {
+        "ids": ["chunk-1", "chunk-2"],
+        "documents": ["alpha", "beta"],
+        "metadatas": [
+            {"collection": "rag_education", "section": "education", "sha256": "a"},
+            {"collection": "rag_education", "section": "education", "sha256": "b"},
+        ],
+        "embeddings": [[0.1, 0.2], [0.3, 0.4]],
+    }
+
+    ids_to_add, docs_to_add, metas_to_add, embs_to_add = select_rows_for_backfill(
+        rows=rows,
+        target_collection="rag_maths_premiere",
+        target_section="maths_premiere",
+        existing_ids={"chunk-2"},
+    )
+
+    assert ids_to_add == ["chunk-1"]
+    assert docs_to_add == ["alpha"]
+    assert metas_to_add == [
+        {"collection": "rag_maths_premiere", "section": "maths_premiere", "sha256": "a"}
+    ]
+    assert embs_to_add == [[0.1, 0.2]]

--- a/tests/test_drive_sync.py
+++ b/tests/test_drive_sync.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from src.ingestor.drive_sync import DriveSyncManager
+
+
+def _file_meta() -> dict[str, str]:
+    return {
+        "id": "file-123",
+        "name": "cours.pdf",
+        "modifiedTime": "2026-04-19T00:00:00Z",
+        "md5Checksum": "abc123",
+    }
+
+
+def test_drive_sync_is_collection_specific_for_dedicated_collections(tmp_path: Path, monkeypatch) -> None:
+    manager = DriveSyncManager(db_path=str(tmp_path / "drive_sync.db"))
+    file_meta = _file_meta()
+
+    manager.mark_as_ingested(file_meta, content_fingerprint="fp-1", collection_name="rag_education")
+
+    monkeypatch.setattr(manager, "_get_drive_service", lambda: object())
+    monkeypatch.setattr(manager, "_fetch_all_files", lambda _service, _folder_id: [file_meta])
+
+    assert manager.list_updates("folder-1", collection_name="rag_education") == []
+    assert manager.list_updates("folder-1", collection_name="rag_maths_premiere") == [file_meta]
+
+
+def test_drive_sync_unchanged_check_uses_collection_scoped_key(tmp_path: Path) -> None:
+    manager = DriveSyncManager(db_path=str(tmp_path / "drive_sync.db"))
+    file_meta = _file_meta()
+
+    manager.mark_as_ingested(file_meta, content_fingerprint="fp-1", collection_name="rag_maths_premiere")
+
+    assert manager.is_unchanged(file_meta, "fp-1", collection_name="rag_maths_premiere") is True
+    assert manager.is_unchanged(file_meta, "fp-1", collection_name="rag_education") is False

--- a/tests/test_ingestor_coverage_extras.py
+++ b/tests/test_ingestor_coverage_extras.py
@@ -490,6 +490,42 @@ def test_prepare_multimodal_chunks(monkeypatch: pytest.MonkeyPatch) -> None:
     assert len(batch.ids) == 2 and batch.modality in {"image", "text"}
 
 
+def test_extract_pdf_documents_from_bytes_falls_back_to_ocr(monkeypatch: pytest.MonkeyPatch) -> None:
+    api = _reload_api(monkeypatch)
+
+    class _Page:
+        def extract_text(self) -> str:
+            return ""
+
+    class _Pdf:
+        pages = [_Page()]
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+    monkeypatch.setattr(api.pdfplumber, "open", lambda *_args, **_kwargs: _Pdf())
+    monkeypatch.setattr(api, "_ocr_pdf_bytes", lambda *_args, **_kwargs: ["Texte OCR page 1"])
+
+    docs = api._extract_pdf_documents_from_bytes(b"%PDF-1.4", "scan.pdf")
+
+    assert len(docs) == 1
+    assert docs[0].page_content == "Texte OCR page 1"
+    assert docs[0].metadata["source"] == "scan.pdf"
+
+
+def test_documents_have_text_ignores_blank_documents(monkeypatch: pytest.MonkeyPatch) -> None:
+    api = _reload_api(monkeypatch)
+    blank_doc = api.Document(page_content="   ", metadata={})
+    text_doc = api.Document(page_content="Texte utile", metadata={})
+
+    assert api._documents_have_text([]) is False
+    assert api._documents_have_text([blank_doc]) is False
+    assert api._documents_have_text([blank_doc, text_doc]) is True
+
+
 def test_load_markdown_empty_and_unreadable(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     api = _reload_api(monkeypatch)
     # empty file

--- a/tests/test_ingestor_security.py
+++ b/tests/test_ingestor_security.py
@@ -387,3 +387,12 @@ def test_collections_requires_auth(monkeypatch: pytest.MonkeyPatch) -> None:
 
     response = client.get("/collections")
     assert response.status_code == 401
+
+
+def test_stats_requires_auth(monkeypatch: pytest.MonkeyPatch) -> None:
+    """GET /stats/{collection} requires authentication."""
+    api = reload_api(monkeypatch, token="stats-secret")
+    client = TestClient(api.app)
+
+    response = client.get("/stats/rag_education")
+    assert response.status_code == 401

--- a/tests/test_ingestor_unit.py
+++ b/tests/test_ingestor_unit.py
@@ -301,6 +301,73 @@ def test_search_omits_documents_when_not_requested(monkeypatch: pytest.MonkeyPat
     ]
 
 
+def test_search_maths_premiere_falls_back_to_education(monkeypatch: pytest.MonkeyPatch) -> None:
+    api = reload_api(monkeypatch, token="search-token")
+
+    class FakeCollection:
+        def __init__(self, name: str) -> None:
+            self.name = name
+
+        def count(self) -> int:
+            if self.name == "rag_maths_premiere":
+                return 0
+            return 10377
+
+        def query(self, **kwargs):
+            assert kwargs["where"] == {
+                "$and": [
+                    {"type_ressource": "Exercices"},
+                    {"matiere": "Mathématiques"},
+                    {"niveau": "Première"},
+                    {"groupe": "Enseignements de spécialité (EDS)"},
+                ]
+            }
+            return {
+                "documents": [["suite"]],
+                "metadatas": [[{"source": "suites.pdf"}]],
+                "ids": [["hit-maths"]],
+                "distances": [[0.11]],
+            }
+
+    class FakeClient:
+        def __init__(self) -> None:
+            self.requested_names: list[str] = []
+
+        def get_or_create_collection(self, name: str, **_kwargs):
+            self.requested_names.append(name)
+            return FakeCollection(name)
+
+    class FakeEmbeddings:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        def embed_query(self, _query):
+            return [0.1, 0.2, 0.3]
+
+    fake_client = FakeClient()
+    monkeypatch.setattr(api, "get_chroma_client", lambda: fake_client)
+    monkeypatch.setattr(api, "TimedOllamaEmbeddings", FakeEmbeddings)
+
+    client = TestClient(api.app)
+    response = client.post(
+        "/search",
+        headers={"X-API-Token": "search-token"},
+        json={
+            "q": "suites",
+            "k": 5,
+            "section": "maths_premiere",
+            "filters": {"type_ressource": "Exercices"},
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["collection"] == "rag_education"
+    assert payload["maths_premiere_fallback"] is True
+    assert payload["returned"] == 1
+    assert fake_client.requested_names == ["rag_maths_premiere", "rag_education"]
+
+
 def test_upload_media_requires_explicit_multimodal_mode(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary
- route Maths Première queries and UI deduplication through dedicated collection-aware behavior
- add a reusable backfill script plus collection-aware Drive sync state for dedicated collections
- recover scanned Drive PDFs during batch ingestion with OCR fallback when loader results contain no usable text

## Validation
- `.venv/bin/pytest tests/test_ingestor_unit.py tests/test_ingestor_security.py tests/test_ingestor_coverage_extras.py tests/test_backfill_dedicated_collection.py tests/test_drive_sync.py -q`
- `.venv/bin/ruff check src/ingestor/api.py src/ingestor/drive_sync.py src/ui/app_v2.py scripts/backfill_dedicated_collection.py tests/test_ingestor_unit.py tests/test_ingestor_security.py tests/test_ingestor_coverage_extras.py tests/test_backfill_dedicated_collection.py tests/test_drive_sync.py`

## Production verification
- Drive task `833abea811f7` finished with `added_chunks=28` on `rag_maths_premiere`
- recovered scanned PDFs in batch ingestion, including `Corr DS GR6.pdf`, `Interrogation.pdf`, `Interrogation(1).pdf`, `Corr Exo3.pdf`, and `Documents scannés.pdf`
- `rag_maths_premiere` now serves Maths Première queries with dedicated OCR-tagged chunks instead of relying on manual one-off ingestion


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes Maths Première searches to a dedicated `rag_maths_premiere` collection with smart fallback, and adds OCR recovery for scanned Drive PDFs. Also makes Drive sync state collection-aware and adds a backfill script plus UI updates.

- **New Features**
  - Dedicated Maths 1ère routing with fallback to `rag_education` + filters when `rag_maths_premiere` is empty; search response includes `maths_premiere_fallback`.
  - OCR fallback for scanned PDFs during Drive ingestion when loader returns no text (pdfplumber first, then Tesseract OCR).
  - Collection-aware Drive sync state to avoid cross-collection collisions.
  - Backfill tool `scripts/backfill_dedicated_collection.py` to copy filtered chunks into a dedicated collection.
  - UI: warns when fallback is active, uses the dedicated collection when available, and de-duplicates “All” search results across collections.

- **Migration**
  - Optional backfill:
    - `python scripts/backfill_dedicated_collection.py --source rag_education --target rag_maths_premiere --section maths_premiere --filter matiere=Mathématiques --filter niveau=Première --filter "groupe=Enseignements de spécialité (EDS)"`
  - Ensure OCR tools are available: `pdftoppm`, `tesseract` (with `fra` and `eng`), and Python libs `pytesseract` and `Pillow`.

<sup>Written for commit 61393b58b94f4812a0ac3b3015415c881d2cc44f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

