### PR TITLE
Fix Drive Office file dispatch during ingestion

### DIFF
--- a/src/ingestor/api.py
+++ b/src/ingestor/api.py
@@ -684,7 +684,7 @@ def _download_drive_file_bytes(file_id: str) -> bytes:
         scopes=["https://www.googleapis.com/auth/drive.readonly"],
     )
     svc = _build("drive", "v3", credentials=creds, cache_discovery=False)
-    return svc.files().get_media(fileId=file_id).execute()
+    return cast(bytes, svc.files().get_media(fileId=file_id).execute())
 
 
 def _documents_have_text(docs: list[Any]) -> bool:

--- a/src/ingestor/api.py
+++ b/src/ingestor/api.py
@@ -532,6 +532,25 @@ def load_docx(file_path: str) -> list[Document]:
     return documents
 
 
+def _load_docx_documents_from_bytes(content_bytes: bytes, source_name: str) -> list[Document]:
+    """Persist Drive DOCX bytes briefly to reuse the existing DOCX loader pipeline."""
+    if not content_bytes:
+        return []
+
+    with tempfile.NamedTemporaryFile(suffix=".docx", delete=False, dir="/tmp") as tmp_docx:
+        tmp_docx.write(content_bytes)
+        tmp_path = tmp_docx.name
+    try:
+        documents = load_docx(tmp_path)
+    finally:
+        Path(tmp_path).unlink(missing_ok=True)
+
+    for document in documents:
+        if not document.metadata.get("source"):
+            document.metadata["source"] = source_name
+    return documents
+
+
 class TimedOllamaEmbeddings(OllamaEmbeddings):
     """Ollama embeddings client with explicit network timeout."""
 
@@ -655,9 +674,41 @@ def _extract_pdf_documents_from_bytes(pdf_bytes: bytes, source_name: str) -> lis
     return docs
 
 
+def _download_drive_file_bytes(file_id: str) -> bytes:
+    from google.oauth2 import service_account as _sa
+    from googleapiclient.discovery import build as _build
+
+    creds_path = os.getenv("GOOGLE_APPLICATION_CREDENTIALS", "")
+    creds = _sa.Credentials.from_service_account_file(
+        creds_path,
+        scopes=["https://www.googleapis.com/auth/drive.readonly"],
+    )
+    svc = _build("drive", "v3", credentials=creds, cache_discovery=False)
+    return svc.files().get_media(fileId=file_id).execute()
+
+
 def _documents_have_text(docs: list[Any]) -> bool:
     """Return True when at least one loaded document has non-empty text content."""
     return any((getattr(doc, "page_content", "") or "").strip() for doc in docs)
+
+
+def _is_pdf_drive_file(file_name: str, mime_type: str) -> bool:
+    return str(file_name or "").lower().endswith(".pdf") or mime_type == "application/pdf"
+
+
+def _is_docx_drive_file(file_name: str, mime_type: str) -> bool:
+    return str(file_name or "").lower().endswith(".docx") or (
+        mime_type == "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+    )
+
+
+def _is_office_spreadsheet_file(file_name: str, mime_type: str) -> bool:
+    file_name_lower = str(file_name or "").lower()
+    spreadsheet_mimes = {
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "application/vnd.ms-excel",
+    }
+    return file_name_lower.endswith((".xlsx", ".xls")) or mime_type in spreadsheet_mimes
 
 
 def _validate_remote_url(url: str) -> None:
@@ -1256,8 +1307,22 @@ def background_drive_ingest(folder_id: str, metadata: dict, task_id: str) -> Non
                 })
                 continue
 
+            if _is_office_spreadsheet_file(fname, mime_type):
+                logger.info(f"[{task_id}] Skipping unsupported spreadsheet Drive file {fid} ({fname}) [{mime_type}]")
+                task.skipped_files += 1
+                task.processed_files += 1
+                task.file_results.append({
+                    "name": fname,
+                    "status": "unsupported",
+                    "added": 0,
+                    "skipped": 1,
+                    "detail": "Type spreadsheet Office non supporté pour ce flux.",
+                })
+                continue
+
             # .doc ancien → conversion libreoffice avant chargement
             is_legacy_doc = fname_lower.endswith(".doc") or mime_type == "application/msword"
+            is_modern_docx = _is_docx_drive_file(fname, mime_type)
 
             try:
                 logger.info(f"[{task_id}] Processing file {fid} ({fname})")
@@ -1292,18 +1357,21 @@ def background_drive_ingest(folder_id: str, metadata: dict, task_id: str) -> Non
                         # Fallback: tenter GoogleDriveLoader
                         docs = []
 
-                # Cas 2 : .doc ancien → libreoffice → .docx → python-docx
+                # Cas 2 : .docx moderne → téléchargement direct → pipeline DOCX
+                elif is_modern_docx:
+                    try:
+                        content_bytes = _download_drive_file_bytes(fid)
+                        docs = _load_docx_documents_from_bytes(content_bytes, fname)
+                        logger.info(f"[{task_id}] .docx loaded directly: {fname}")
+                    except Exception as _e:
+                        logger.warning(f"[{task_id}] .docx load failed for {fid}: {_e}")
+                        docs = []
+
+                # Cas 3 : .doc ancien → libreoffice → .docx → python-docx
                 elif is_legacy_doc:
                     try:
-                        from google.oauth2 import service_account as _sa
-                        from googleapiclient.discovery import build as _build
                         import subprocess
-                        _creds_path = os.getenv("GOOGLE_APPLICATION_CREDENTIALS", "")
-                        _creds = _sa.Credentials.from_service_account_file(
-                            _creds_path, scopes=["https://www.googleapis.com/auth/drive.readonly"]
-                        )
-                        _svc = _build("drive", "v3", credentials=_creds, cache_discovery=False)
-                        content_bytes = _svc.files().get_media(fileId=fid).execute()
+                        content_bytes = _download_drive_file_bytes(fid)
                         with tempfile.NamedTemporaryFile(suffix=".doc", delete=False, dir="/tmp") as tf:
                             tf.write(content_bytes)
                             tmp_doc = tf.name
@@ -1324,23 +1392,15 @@ def background_drive_ingest(folder_id: str, metadata: dict, task_id: str) -> Non
                         logger.warning(f"[{task_id}] .doc conversion failed for {fid}: {_e}")
                         docs = []
 
-                # Cas 3 : chargement standard via GoogleDriveLoader
-                if not docs and mime_type not in google_workspace_export and not is_legacy_doc:
+                # Cas 4 : chargement standard via GoogleDriveLoader
+                if not docs and mime_type not in google_workspace_export and not is_legacy_doc and not is_modern_docx:
                     kwargs = loader_kwargs_base.copy()
                     kwargs["file_ids"] = [fid]
                     try:
                         loader = GoogleDriveLoader(**kwargs)
                         docs = loader.load()
-                        if not _documents_have_text(docs) and mime_type == "application/pdf":
-                            from google.oauth2 import service_account as _sa2
-                            from googleapiclient.discovery import build as _build2
-
-                            _creds_path2 = os.getenv("GOOGLE_APPLICATION_CREDENTIALS", "")
-                            _creds2 = _sa2.Credentials.from_service_account_file(
-                                _creds_path2, scopes=["https://www.googleapis.com/auth/drive.readonly"]
-                            )
-                            _svc2 = _build2("drive", "v3", credentials=_creds2, cache_discovery=False)
-                            pdf_bytes = _svc2.files().get_media(fileId=fid).execute()
+                        if not _documents_have_text(docs) and _is_pdf_drive_file(fname, mime_type):
+                            pdf_bytes = _download_drive_file_bytes(fid)
                             docs = _extract_pdf_documents_from_bytes(pdf_bytes, fname)
                             if docs:
                                 logger.info(f"[{task_id}] pdf/OCR fallback OK after empty loader result: {fname}")
@@ -1348,16 +1408,9 @@ def background_drive_ingest(folder_id: str, metadata: dict, task_id: str) -> Non
                         error_detail = str(e)
                         # Fallback pdfplumber pour PDFs corrompus (EOF marker not found)
                         pdf_error_markers = ("eof marker", "startxref", "cannot read an empty", "trailer", "malformed pdf", "invalid pdf", "file is not a pdf")
-                        if any(m in error_detail.lower() for m in pdf_error_markers):
+                        if _is_pdf_drive_file(fname, mime_type) and any(m in error_detail.lower() for m in pdf_error_markers):
                             try:
-                                from google.oauth2 import service_account as _sa2
-                                from googleapiclient.discovery import build as _build2
-                                _creds_path2 = os.getenv("GOOGLE_APPLICATION_CREDENTIALS", "")
-                                _creds2 = _sa2.Credentials.from_service_account_file(
-                                    _creds_path2, scopes=["https://www.googleapis.com/auth/drive.readonly"]
-                                )
-                                _svc2 = _build2("drive", "v3", credentials=_creds2, cache_discovery=False)
-                                pdf_bytes = _svc2.files().get_media(fileId=fid).execute()
+                                pdf_bytes = _download_drive_file_bytes(fid)
                                 docs = _extract_pdf_documents_from_bytes(pdf_bytes, fname)
                                 if docs:
                                     logger.info(f"[{task_id}] pdf/OCR fallback OK: {fname} ({len(docs)} pages)")

--- a/tests/test_ingestor_unit.py
+++ b/tests/test_ingestor_unit.py
@@ -368,6 +368,69 @@ def test_search_maths_premiere_falls_back_to_education(monkeypatch: pytest.Monke
     assert fake_client.requested_names == ["rag_maths_premiere", "rag_education"]
 
 
+def test_background_drive_ingest_loads_docx_files(monkeypatch: pytest.MonkeyPatch) -> None:
+    api = reload_api(monkeypatch, token="drive-token")
+
+    file_meta = {
+        "id": "docx-1",
+        "name": "cours.docx",
+        "mimeType": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        "modifiedTime": "2026-04-19T07:00:00Z",
+    }
+    task = api.DriveTaskProgress(task_id="task-docx", folder_id="folder", target_collection="rag_maths_premiere")
+    api._drive_tasks["task-docx"] = task
+
+    monkeypatch.setattr(api.sync_manager, "verify_folder_access", lambda _folder_id: {"id": "folder"})
+    monkeypatch.setattr(api.sync_manager, "list_updates", lambda _folder_id, collection_name=None: [file_meta])
+    monkeypatch.setattr(api.sync_manager, "is_unchanged", lambda *args, **kwargs: False)
+    monkeypatch.setattr(api.sync_manager, "mark_as_ingested", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        api,
+        "_load_docx_documents_from_bytes",
+        lambda content_bytes, source_name: [api.Document(page_content="DOCX texte", metadata={"source": source_name})],
+    )
+    monkeypatch.setattr(api, "_download_drive_file_bytes", lambda file_id: b"docx-bytes")
+    monkeypatch.setattr(
+        api,
+        "_prepare_chunks_for_chroma",
+        lambda req, docs, extra_metadata=None: api.PreparedBatch(
+            ids=["h1"],
+            documents=[docs[0].page_content],
+            metadatas=[{"source": docs[0].metadata["source"]}],
+            modality="text",
+        ),
+    )
+    monkeypatch.setattr(api, "_index_batch", lambda *args, **kwargs: {"added": 1, "skipped": 0})
+
+    api.background_drive_ingest("folder", {"collection": "rag_maths_premiere"}, "task-docx")
+
+    assert task.status == "done"
+    assert task.file_results[0]["status"] == "ok"
+    assert task.added_chunks == 1
+
+
+def test_background_drive_ingest_marks_xlsx_as_unsupported(monkeypatch: pytest.MonkeyPatch) -> None:
+    api = reload_api(monkeypatch, token="drive-token")
+
+    file_meta = {
+        "id": "xlsx-1",
+        "name": "planning.xlsx",
+        "mimeType": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "modifiedTime": "2026-04-19T07:00:00Z",
+    }
+    task = api.DriveTaskProgress(task_id="task-xlsx", folder_id="folder", target_collection="rag_maths_premiere")
+    api._drive_tasks["task-xlsx"] = task
+
+    monkeypatch.setattr(api.sync_manager, "verify_folder_access", lambda _folder_id: {"id": "folder"})
+    monkeypatch.setattr(api.sync_manager, "list_updates", lambda _folder_id, collection_name=None: [file_meta])
+
+    api.background_drive_ingest("folder", {"collection": "rag_maths_premiere"}, "task-xlsx")
+
+    assert task.status == "done"
+    assert task.file_results[0]["status"] == "unsupported"
+    assert "spreadsheet" in task.file_results[0]["detail"].lower()
+
+
 def test_upload_media_requires_explicit_multimodal_mode(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary
- load Drive `.docx` files through the existing DOCX pipeline instead of letting them fall into the generic loader path
- classify Office spreadsheets (`.xlsx/.xls`) as unsupported for this ingest flow instead of misreporting them as PDF errors
- restrict the PDF fallback path to actual PDF files only

## Validation
- `/home/alaeddine/Bureau/rag-local/.venv/bin/ruff check src/ingestor/api.py tests/test_ingestor_unit.py`
- `/home/alaeddine/Bureau/rag-local/.venv/bin/pytest tests/test_ingestor_unit.py::test_background_drive_ingest_loads_docx_files tests/test_ingestor_unit.py::test_background_drive_ingest_marks_xlsx_as_unsupported tests/test_ingestor_coverage_extras.py::test_extract_pdf_documents_from_bytes_falls_back_to_ocr -q`
- `/home/alaeddine/Bureau/rag-local/.venv/bin/pytest tests/test_ingestor_unit.py tests/test_ingestor_coverage_extras.py -q`

## Production goal
Reduce Drive ingest noise in the Maths Première folder by stopping `.docx/.xlsx` files from being misclassified as `invalid pdf`, while keeping the OCR PDF recovery path intact.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Drive ingestion routing for Office files: `.docx` now uses the DOCX pipeline, spreadsheets are skipped as unsupported, and PDF fallbacks run only for real PDFs. This removes “invalid pdf” noise and improves ingest accuracy in the Maths Première folder.

- **Bug Fixes**
  - Load Drive `.docx` by downloading bytes via a typed helper and reusing the DOCX loader; preserves source metadata.
  - Mark `.xlsx`/`.xls` as unsupported and report a clear status instead of PDF errors.
  - Gate OCR/PDF fallback to files detected as PDFs only; other types use the standard path.

<sup>Written for commit 8508b432b511f2251ddb5fc17d6979c0d91aaf68. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

